### PR TITLE
fix(provider): Change invalid type

### DIFF
--- a/lua/whiskyline/provider.lua
+++ b/lua/whiskyline/provider.lua
@@ -258,7 +258,7 @@ end
 function pd.gitdelete()
   local result = {
     stl = function()
-      local res = gitsigns_data('deleted')
+      local res = gitsigns_data('removed')
       return #res > 0 and git_icons('deleted') .. res or ''
     end,
     name = 'gitdelete',


### PR DESCRIPTION
## Description

Basically the type you were sending `deleted` is not a valid key in the `vim.b.gitsigns_status_dict` function, it just returns 
![image](https://user-images.githubusercontent.com/62358156/230746391-1e0a54f7-c2d2-4ad5-9b3b-059c432b1504.png)

So I changed the type you send to `gitsigns_data()` so that it works as expected. 
Let me know if you want me to semantically rename the rest so that I can keep the clean.